### PR TITLE
allow cuda <0.8 instead of <0.7

### DIFF
--- a/cublas.cabal
+++ b/cublas.cabal
@@ -47,7 +47,7 @@ library
        
 
   build-depends:        base >=4.4 && <4.9,
-                        cuda >=0.4.1 && <0.7,
+                        cuda >=0.4.1 && <0.8,
                         filepath >=1.3 && <1.5,
                         language-c >=0.4.2 && <0.5,
                         template-haskell >=2.7 && <2.11,


### PR DESCRIPTION
I'm currently using the _cuda_ package (version 0.7._something_) with this one, so this change was necessary. I'm forced to use ghc-7.10 with the _cuda_ package as it is now to avoid some issue, so I didn't have to change the _base_ bound, only the _cuda_ one.
